### PR TITLE
Implement per-user sorting rules file

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -111,6 +111,7 @@ scripts/test.sh
 - 2025-06-21 11:00 Price/js/filters.js, Price/js/tabs.js, Price/js/data-loader.js, docs/js_index.md – правка фильтрации по вкладкам.
 - 2025-06-22 docs/columns/README.md – добавлено описание процесса вывода столбцов.
 - 2025-06-23 Price/js/rules-loader.js, docs/columns/README.md – правила сортировки вынесены в JSON.
+- 2025-06-24 Price/admin.php, Price/login.php, Price/index.php, Price/js/rules-loader.js – индивидуальный файл правил для пользователей.
 
 
 ## Рекомендации по улучшению

--- a/Price/admin.php
+++ b/Price/admin.php
@@ -274,6 +274,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['saveChanges'])) {
       if (!empty($newPassword)) {
           $u['password_hash'] = password_hash($newPassword, PASSWORD_DEFAULT);
       }
+
+      // 4) Файл правил
+      $u['rules_file'] = $_POST['rules_file'][$index] ?? 'row_sort_rules.json';
   }
 
   // Переписываем индексы и сохраняем
@@ -291,6 +294,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['addUser'])) {
   $newPassword = trim($_POST['new_password'] ?? '');
   $newHref     = $_POST['new_href'] ?? '';
   $newDiscount = isset($_POST['new_discount']) ? (int)$_POST['new_discount'] : 0;
+  $newRulesFile = trim($_POST['new_rules_file'] ?? 'row_sort_rules.json');
 
   // Группы товаров (href)
   $newFolders = $_POST['new_productfolder_hrefs'] ?? []; // массив href
@@ -343,7 +347,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['addUser'])) {
           'href' => $newHref,
           'name' => $foundCounterparty['name'] ?? ''
       ],
-      'productfolders' => $productFoldersData
+      'productfolders' => $productFoldersData,
+      'rules_file' => $newRulesFile ?: 'row_sort_rules.json'
   ];
 
   saveUsers($users);
@@ -416,6 +421,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['addUser'])) {
             <th>Скидка %</th>
             <th>Новый пароль</th>
             <th>Группы товаров</th>
+            <th>Файл правил</th>
             <th>Удалить?</th>
         </tr>
         <?php foreach ($users as $index => $u): ?>
@@ -482,6 +488,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['addUser'])) {
                     </div>
                 </td>
 
+                <!-- Файл правил -->
+                <td>
+                    <input type="text" name="rules_file[<?= $index ?>]" value="<?= htmlspecialchars($u['rules_file'] ?? 'row_sort_rules.json') ?>">
+                </td>
+
                 <!-- Удалить -->
                 <td style="text-align:center;">
                     <input type="checkbox" name="delete[<?= $index ?>]" value="1">
@@ -543,6 +554,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['addUser'])) {
         <?php endforeach; ?>
     </div>
     <br>
+
+    <label>Файл правил:
+        <input type="text" name="new_rules_file" value="row_sort_rules.json">
+    </label>
+    <br><br>
 
     <button type="submit">Создать пользователя</button>
 </form>

--- a/Price/index.php
+++ b/Price/index.php
@@ -9,6 +9,7 @@ if (!isset($_SESSION['user'])) {
 }
 $username = $_SESSION['user']['login'];
 $userFolders = $_SESSION['user']['productfolders'] ?? [];
+$rulesFile = $_SESSION['user']['rules_file'] ?? 'row_sort_rules.json';
 ?>
 <!DOCTYPE html>
 <html lang="ru">
@@ -279,6 +280,7 @@ $userFolders = $_SESSION['user']['productfolders'] ?? [];
 
 
 <script>window.__userFolders = <?php echo json_encode($userFolders, JSON_UNESCAPED_UNICODE); ?>;</script>
+<script>window.__rulesFile = <?php echo json_encode($rulesFile, JSON_UNESCAPED_UNICODE); ?>;</script>
 <script src="js/data-loader.js"></script>
 <script src="js/tabs.js"></script>
 <script src="js/table.js"></script>

--- a/Price/js/rules-loader.js
+++ b/Price/js/rules-loader.js
@@ -3,8 +3,9 @@
  * @returns {Promise<void>}
  */
 function loadRules() {
+  const rulesFile = window.__rulesFile || 'row_sort_rules.json';
   const colPromise = fetch('column_rules.json').then(r => r.json());
-  const sortPromise = fetch('row_sort_rules.json').then(r => r.json());
+  const sortPromise = fetch(rulesFile).then(r => r.json());
   return Promise.all([colPromise, sortPromise]).then(([cols, sort]) => {
     COLUMN_RULES = Array.isArray(cols) ? cols : [];
     COUNTRY_ORDER = Array.isArray(sort.countryOrder) ? sort.countryOrder : [];

--- a/Price/login.php
+++ b/Price/login.php
@@ -36,7 +36,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 'role'             => $u['role'],
                 'counterparty_href'=> $u['counterparty_href'] ?? '',
                 'discount'         => $u['discount'] ?? 0,
-                'productfolders'   => $u['productfolders'] ?? [] // <-- добавляем сюда
+                'productfolders'   => $u['productfolders'] ?? [], // <-- добавляем сюда
+                'rules_file'       => $u['rules_file'] ?? 'row_sort_rules.json'
             ];
             // Редирект в зависимости от роли
             if ($u['role'] === 'admin') {

--- a/Price/users.json
+++ b/Price/users.json
@@ -4,7 +4,8 @@
         "password_hash": "$2y$10$SNF6LPDmYXSFQ0TnKN9RT.1VJbHKM4d0.FFHh3qPql4CyesQH2cN2",
         "role": "admin",
         "counterparty_href": "https:\/\/api.moysklad.ru\/api\/remap\/1.2\/entity\/counterparty\/b332da86-2958-11e9-9107-50480008abdb",
-        "discount": 0
+        "discount": 0,
+        "rules_file": "row_sort_rules.json"
     },
     {
         "login": "test2",
@@ -20,7 +21,8 @@
                 "href": "https:\/\/api.moysklad.ru\/api\/remap\/1.2\/entity\/productfolder\/80b4500a-ab15-11ef-0a80-0c1000369750",
                 "name": "ОПТ JFK"
             }
-        ]
+        ],
+        "rules_file": "row_sort_rules.json"
     },
     {
         "login": "domika",
@@ -31,6 +33,7 @@
             "href": "https:\/\/api.moysklad.ru\/api\/remap\/1.2\/entity\/counterparty\/0176bed6-2c25-11e8-9107-5048000555c7",
             "name": "ООО \"МЕДКОВ\""
         },
-        "productfolders": []
+        "productfolders": [],
+        "rules_file": "row_sort_rules.json"
     }
 ]

--- a/docs/admin/php.md
+++ b/docs/admin/php.md
@@ -27,7 +27,8 @@
   "role": "user"|"admin",
   "discount": 0,
   "counterparty": {"href": "", "name": ""},
-  "productfolders": [{"href": "", "name": ""}, ...]
+  "productfolders": [{"href": "", "name": ""}, ...],
+  "rules_file": "row_sort_rules.json"
 }
 ```
 

--- a/docs/columns/README.md
+++ b/docs/columns/README.md
@@ -71,6 +71,8 @@ JSON‑файлов `row_sort_rules.json` и `column_rules.json`. Скрипт `
 `COUNTRY_ORDER`, `TYPE_ORDER` и `COLUMN_RULES`. `fillTable` и `fillFilters`
 используют эти данные для сортировки и построения таблицы. Отсутствующие в
 правилах значения сортируются по алфавиту.
+Начиная с версии 2025‑06‑24 путь к файлу `row_sort_rules.json` можно задать
+для каждого пользователя через поле `rules_file` в `users.json`.
 
 ## История изменений
 


### PR DESCRIPTION
## Summary
- support per-user JSON rules file specified in `users.json`
- add UI in admin panel to edit `rules_file`
- propagate selected file through login and index pages
- load rules from `window.__rulesFile` in `rules-loader.js`
- document the new option

## Testing
- `php -l Price/admin.php`
- `php -l Price/login.php`
- `php -l Price/index.php`
- `scripts/test.sh` *(fails: phpunit is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683dd70bd94c832099afd0beafeacb8e