### PR TITLE
Fix data groups

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -138,6 +138,7 @@ scripts/test.sh
 - 2025-06-27 10:20 webhook.php – исправлен заголовок Accept в запросах.
 - 2025-11-01 output/init_db.php, docs/php/init_db.md – скрипт начальной загрузки базы товаров и модификаций.
 - 2025-11-02 Price/data.php, docs/php/data.md – расширено логирование работы скрипта.
+- 2025-06-27 11:16 Price/data.php – расширен список ALWAYS_SHOW_GROUPS.
 
 
 ## Рекомендации по улучшению

--- a/Price/data.php
+++ b/Price/data.php
@@ -466,7 +466,7 @@ foreach ($combinedItems as $uniqueId => $d) {
     // Отбрасываем дробную часть и исключаем товары с нулевым остатком,
     // кроме групп, которые всегда должны отображаться
     $totalStockInt = (int) floor($totalStock);
-    $alwaysShow = ['Ароматизированный чай', 'Приправы'];
+    $alwaysShow = ['Ароматизированный чай', 'Травы и добавки', 'Приправы'];
     if ($totalStockInt <= 0 && !in_array($d['group'], $alwaysShow, true)) {
         continue;
     }


### PR DESCRIPTION
## Summary
- show 'Herbs and additives' items even with zero stock
- document the change

## Testing
- `php -l Price/data.php`
- `scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_685e7c8375c483209a229103bb2e56a8