### PR TITLE
Fix parsing of API report

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -141,6 +141,7 @@ scripts/test.sh
 - 2025-11-03 Price/data.php, docs/php/data.md – введена константа DEBUG_LOG для детального логирования.
 - 2025-06-27 11:16 Price/data.php – расширен список ALWAYS_SHOW_GROUPS.
 - 2025-06-27 11:20 Price/data.php – подробное логирование причин исключения товаров.
+- 2025-06-27 12:24 Price/data.php – разбор строк отчёта без поля `assortment`.
 
 
 ## Рекомендации по улучшению


### PR DESCRIPTION
## Summary
- handle rows without `assortment` field in stock report
- document change

## Testing
- `php -l Price/data.php`
- `bash scripts/test.sh`


------
https://chatgpt.com/codex/tasks/task_e_685e8ae76f108320963b44fd8bbf9669