### PR TITLE
Fix type sorting

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -165,6 +165,7 @@ scripts/test.sh
 - 2025-11-13 Price/data.php, docs/php/data.md – логирование группы при исключении товара с нулевым остатком.
 - 2025-11-14 Price/data.php, docs/php/data.md – сначала берём данные из локальной базы, затем сравниваем с отчётом.
 - 2025-11-15 Price/data.php, docs/php/data.md – отчёт stock/bystore с stockType=quantity, значение в поле quantity.
+- 2025-11-16 Price/js/table.js, Price/js/filters.js – типы сортируются внутри каждой страны без учёта регистра.
 
 
 

--- a/Price/js/filters.js
+++ b/Price/js/filters.js
@@ -17,7 +17,7 @@ function applyFilters() {
   const filtered = allData.filter(item => {
     if (valArticul && !item.articul.toLowerCase().includes(valArticul)) return false;
     if (valName && !item.name.toLowerCase().includes(valName)) return false;
-    if (valTip && item.tip !== valTip) return false;
+    if (valTip && normalizeType(item.tip) !== valTip) return false;
     if (valCountry && item.supplier !== valCountry) return false;
 
     const mass = parseFloat(item.mass) || 0;

--- a/Price/js/table.js
+++ b/Price/js/table.js
@@ -40,13 +40,17 @@ function normalizeCountry(value) {
   return (value || '').trim().toUpperCase();
 }
 
+function normalizeType(value) {
+  return (value || '').trim().toUpperCase();
+}
+
 function sortByCountry(data) {
   const countryMap = COUNTRY_ORDER.reduce((acc, c, i) => {
     acc[normalizeCountry(c)] = i;
     return acc;
   }, {});
   const typeMap = TYPE_ORDER.reduce((acc, t, i) => {
-    acc[t] = i;
+    acc[normalizeType(t)] = i;
     return acc;
   }, {});
   const sortAlpha = TYPE_SORT === 'alphabetical' || TYPE_ORDER.length === 0;
@@ -57,8 +61,8 @@ function sortByCountry(data) {
     const bi = countryMap.hasOwnProperty(bCountry) ? countryMap[bCountry] : COUNTRY_ORDER.length;
     if (ai !== bi) return ai - bi;
 
-    const aType = a.tip || '';
-    const bType = b.tip || '';
+    const aType = normalizeType(a.tip);
+    const bType = normalizeType(b.tip);
     const ati = typeMap.hasOwnProperty(aType) ? typeMap[aType] : TYPE_ORDER.length;
     const bti = typeMap.hasOwnProperty(bType) ? typeMap[bType] : TYPE_ORDER.length;
     if (!sortAlpha && (ati !== bti)) return ati - bti;
@@ -93,15 +97,17 @@ function orderCountriesList(list) {
  */
 function orderTypesList(list) {
   const map = TYPE_ORDER.reduce((acc, t, i) => {
-    acc[t] = i;
+    acc[normalizeType(t)] = i;
     return acc;
   }, {});
   const sortAlpha = TYPE_SORT === 'alphabetical' || TYPE_ORDER.length === 0;
   return list.slice().sort((a, b) => {
-    const ai = map.hasOwnProperty(a) ? map[a] : TYPE_ORDER.length;
-    const bi = map.hasOwnProperty(b) ? map[b] : TYPE_ORDER.length;
+    const aNorm = normalizeType(a);
+    const bNorm = normalizeType(b);
+    const ai = map.hasOwnProperty(aNorm) ? map[aNorm] : TYPE_ORDER.length;
+    const bi = map.hasOwnProperty(bNorm) ? map[bNorm] : TYPE_ORDER.length;
     if (!sortAlpha && (ai !== bi)) return ai - bi;
-    return a.localeCompare(b);
+    return aNorm.localeCompare(bNorm);
   });
 }
 
@@ -166,7 +172,7 @@ function fillTable(data) {
   const chunkSize = 50;
   let rowNumber = 1;
   let currentCountry = null;
-  let currentType = null;
+  let currentType = null; // normalized type name
 
   const colSpan = COLUMN_RULES.length || 11;
 
@@ -205,12 +211,13 @@ function fillTable(data) {
         currentType = null;
       }
 
-      if (currentType !== (item.tip || '')) {
+      const itemTypeNorm = normalizeType(item.tip);
+      if (currentType !== itemTypeNorm) {
         const typeHeader = document.createElement('tr');
         typeHeader.className = 'type-row';
         typeHeader.innerHTML = `<td colspan="${colSpan}">${item.tip || ''}</td>`;
         tbody.appendChild(typeHeader);
-        currentType = item.tip || '';
+        currentType = itemTypeNorm;
       }
 
       const tr = document.createElement('tr');
@@ -275,13 +282,18 @@ function fillTable(data) {
  */
 function fillFilters(data) {
   const tipSelect = document.getElementById('filterTip');
-  const types = [...new Set(data.map(i => i.tip).filter(Boolean))];
-  const orderedTypes = orderTypesList(types);
+  const typeMap = new Map();
+  data.forEach(i => {
+    if (!i.tip) return;
+    const norm = normalizeType(i.tip);
+    if (!typeMap.has(norm)) typeMap.set(norm, i.tip);
+  });
+  const orderedTypes = orderTypesList([...typeMap.keys()]);
   tipSelect.innerHTML = '<option value="">(Все)</option>';
   orderedTypes.forEach(t => {
     const opt = document.createElement('option');
     opt.value = t;
-    opt.textContent = t;
+    opt.textContent = typeMap.get(t) || t;
     tipSelect.appendChild(opt);
   });
 

--- a/docs/js_index.md
+++ b/docs/js_index.md
@@ -87,3 +87,4 @@
 - 2025-11-07 Price/data.php, Price/js/table.js – удалена группа «Травы и добавки» из ALWAYS_SHOW_GROUPS.
 - 2025-11-10 12:15 Price/data.php, Price/js/table.js – возвращена группа «Травы и добавки» в ALWAYS_SHOW_GROUPS.
 
+- 2025-11-16 Price/js/table.js – сортировка типов внутри каждой страны не зависит от регистра.


### PR DESCRIPTION
## Summary
- respect type order per country regardless of case
- show original type text in filter dropdown
- document type ordering fix

## Testing
- `scripts/test.sh` *(phpunit is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6863bda19d488320ba29288a8660ad29