### PR TITLE
Adjust error placement in login form

### DIFF
--- a/Price/auth.php
+++ b/Price/auth.php
@@ -61,10 +61,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   <link rel="stylesheet" type="text/css" href="styles/auth.css">
 </head>
 <body>
-  <?php if ($error): ?>
-    <p class="error"><?php echo htmlspecialchars($error); ?></p>
-  <?php endif; ?>
   <div class="login-container">
+    <?php if ($error): ?>
+      <p class="error"><?php echo htmlspecialchars($error); ?></p>
+    <?php endif; ?>
     <form id="loginForm" method="post" action="auth.php">
       <label><input type="text" name="login" placeholder="Логин" required></label><br>
       <label><input type="password" name="password" placeholder="Пароль" required></label><br>


### PR DESCRIPTION
## Summary
- move login error message inside `.login-container` so it's above the form

## Testing
- `php -l Price/auth.php`
- `scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a8a700da08320be2b3280d158f637