### PR TITLE
Align admin panel style with login page

### DIFF
--- a/Price/admin.php
+++ b/Price/admin.php
@@ -599,6 +599,7 @@ $username = $_SESSION['user']['login'];
     
 </head>
 <body class="ms-login-field">
+<div class="admin-container">
 <h2>Админ-панель</h2>
 <p class="user-info">
     Вы вошли как: <strong><?= htmlspecialchars($username) ?></strong>
@@ -866,6 +867,7 @@ $username = $_SESSION['user']['login'];
 
     <button type="submit" class="btn-msk btn-success">Создать пользователя</button>
 </form>
+</div>
 
 <script>
 var countries = <?= json_encode($countriesList, JSON_UNESCAPED_UNICODE) ?>;

--- a/Price/styles/admin.css
+++ b/Price/styles/admin.css
@@ -1,5 +1,37 @@
 /* Styles for admin panel */
 
+body {
+    font-family: Arial, sans-serif;
+    color: #333;
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    min-height: 100vh;
+    margin: 0;
+    position: relative;
+}
+
+body::before {
+    content: "";
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background: url('tea.jpg') center/cover no-repeat;
+    opacity: 0.6;
+    z-index: -1;
+}
+
+.admin-container {
+    background-color: rgba(255, 255, 255, 0.25);
+    backdrop-filter: blur(10px);
+    border-radius: 12px;
+    box-shadow: 0 4px 10px rgba(0,0,0,0.1);
+    padding: 20px;
+    max-width: 1200px;
+    width: 95%;
+    box-sizing: border-box;
+    border: 1px solid rgba(255,255,255,0.3);
+}
+
 .error {
     padding: 10px;
     margin: 10px 0;


### PR DESCRIPTION
## Summary
- apply same glass background as login page for admin panel
- wrap admin layout in styled container

## Testing
- `php -l Price/admin.php`
- `scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_688b7d07e8848320b0785f5e74b802e2