### PR TITLE
Add header section to admin page

### DIFF
--- a/Price/admin.php
+++ b/Price/admin.php
@@ -594,8 +594,10 @@ $username = $_SESSION['user']['login'];
     
 </head>
 <body class="ms-login-field">
+<header class="admin-header">
+    <h2>Админ-панель</h2>
+</header>
 <div class="admin-container">
-<h2>Админ-панель</h2>
 <p class="user-info">
     Вы вошли как: <strong><?= htmlspecialchars($username) ?></strong>
     <a href="logout.php" class="logout-link">Выйти</a>

--- a/Price/styles/admin.css
+++ b/Price/styles/admin.css
@@ -32,6 +32,21 @@ body::before {
     border: 1px solid rgba(255,255,255,0.3);
 }
 
+/* Header bar for admin page */
+.admin-header {
+    background-color: rgba(255, 255, 255, 0.4);
+    backdrop-filter: blur(10px);
+    border-radius: 12px;
+    box-shadow: 0 4px 10px rgba(0,0,0,0.1);
+    padding: 20px;
+    margin: 20px;
+    box-sizing: border-box;
+    border: 1px solid rgba(255,255,255,0.3);
+}
+.admin-header h2 {
+    margin: 0;
+}
+
 .error {
     padding: 10px;
     margin: 10px 0;


### PR DESCRIPTION
## Summary
- add a new `admin-header` section above the admin panel
- style header similarly to admin container but with 0.4 opacity

## Testing
- `php -l Price/admin.php`
- `scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_688bb1db7a7c832088601fe00e05f8ce