### PR TITLE
Adjust add-user form field widths

### DIFF
--- a/Price/styles/admin.css
+++ b/Price/styles/admin.css
@@ -264,6 +264,14 @@ a:hover {
     display: block;
     margin-left: auto;
     margin-right: auto;
-    width: fit-content;
+    width: 100%;
+    max-width: 400px;
+}
+
+/* Stretch login and password fields to form width */
+.add-user-form input[type="text"],
+.add-user-form input[type="password"] {
+    width: 100%;
+    box-sizing: border-box;
 }
 


### PR DESCRIPTION
## Summary
- enlarge Add User form's login and password inputs to span the full width

## Testing
- `scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_688be7ce126483208b6054d881b447ea