### PR TITLE
Remove password hashing

### DIFF
--- a/Price/admin.php
+++ b/Price/admin.php
@@ -501,7 +501,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['saveChanges'])) {
       // 3) Новый пароль (если задан)
       $newPassword = $_POST['new_password'][$index] ?? '';
       if (!empty($newPassword)) {
-          $u['password_hash'] = password_hash($newPassword, PASSWORD_DEFAULT);
+          $u['password'] = $newPassword;
       }
 
   }
@@ -515,7 +515,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['saveChanges'])) {
 }
 
 
-// ------------------ ADD NEW USER (role=user, password_hash) ------------------
+// ------------------ ADD NEW USER (role=user, password) ------------------
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['addUser'])) {
   $newLogin    = trim($_POST['new_login'] ?? '');
   $newPassword = trim($_POST['new_password'] ?? '');
@@ -564,9 +564,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['addUser'])) {
   }
 
   // Добавляем нового пользователя
-  $users[] = [
+    $users[] = [
       'login'       => $newLogin,
-      'password_hash' => password_hash($newPassword, PASSWORD_DEFAULT),
+      'password'    => $newPassword,
       'role'        => 'user',
       'discount'    => max(0, min(100, $newDiscount)),
       'counterparty'=> [

--- a/Price/auth.php
+++ b/Price/auth.php
@@ -29,8 +29,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $users = loadUsers();
 
     foreach ($users as $u) {
-        // Проверяем совпадение логина и хэш пароля
-        if ($u['login'] === $login && password_verify($pass, $u['password_hash'])) {
+        // Проверяем совпадение логина и пароля
+        if ($u['login'] === $login && $pass === ($u['password'] ?? '')) {
             // Успешный вход: сохраняем данные пользователя в сессии
             $_SESSION['user'] = [
                 'login'            => $u['login'],

--- a/Price/casa/xNtxj6hsL2.json
+++ b/Price/casa/xNtxj6hsL2.json
@@ -1,7 +1,7 @@
 [
     {
         "login": "admin",
-        "password_hash": "$2y$10$SNF6LPDmYXSFQ0TnKN9RT.1VJbHKM4d0.FFHh3qPql4CyesQH2cN2",
+        "password": "adminpass",
         "role": "admin",
         "counterparty_href": "https:\/\/api.moysklad.ru\/api\/remap\/1.2\/entity\/counterparty\/b332da86-2958-11e9-9107-50480008abdb",
         "discount": 0,
@@ -9,7 +9,7 @@
     },
     {
         "login": "test2",
-        "password_hash": "$2y$10$SxIZUkn40GLgsLOt6UazcubScYKEfLE776uGIT7d\/.iK9.OKJSJ5O",
+        "password": "test2pass",
         "role": "user",
         "discount": 30,
         "counterparty": {
@@ -26,7 +26,7 @@
     },
     {
         "login": "dommika",
-        "password_hash": "$2y$10$3u1l.s\/K6FoiH.\/QkVpS3Oa7PyEjlrrdD3BZMPVubK3EIgUcGYgoa",
+        "password": "dommikapass",
         "role": "user",
         "discount": 0,
         "counterparty": {

--- a/Price/init.php
+++ b/Price/init.php
@@ -3,7 +3,7 @@ require_once 'data.php';
 $users = loadUsers();
 $users[] = [
     "login" => "admin",
-    "password_hash" => password_hash("adminpass", PASSWORD_DEFAULT),
+    "password" => "adminpass",
     "role" => "admin",
     "counterparty_href" => "",
     "discount" => 0


### PR DESCRIPTION
## Summary
- store plaintext passwords in user JSON
- check passwords in plain form during login
- save new passwords in plain form when editing or adding users
- initialize admin user with plaintext password

## Testing
- `scripts/install.sh`
- `php -l Price/auth.php`
- `php -l Price/admin.php`
- `php -l Price/init.php`
- `scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_688cf9d406a483208cc0bd214608dc24