### PR TITLE
Expand select width in user modal

### DIFF
--- a/Price/styles/admin.css
+++ b/Price/styles/admin.css
@@ -225,6 +225,11 @@ label {
     margin: 0.5em 0;
 }
 
+/* Ensure labels in the "Add User" form span the full width */
+.add-user-form label {
+    width: 100%;
+}
+
 input[type="text"], input[type="password"], input[type="number"], select {
     padding: 5px;
     margin-left: 10px;
@@ -299,6 +304,12 @@ a:hover {
 /* Stretch fields in the "Add User" form */
 .add-user-form select {
     width: 100%;
+    box-sizing: border-box;
+}
+
+/* Select2 container should also stretch across the available width */
+.add-user-form .select2-container {
+    width: 100% !important;
     box-sizing: border-box;
 }
 


### PR DESCRIPTION
## Summary
- stretch labels within the add user form
- ensure Select2 container uses full width

## Testing
- `php -l Price/admin.php`
- `scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_688d36755fd08320bc8a063336c85675