### PR TITLE
Fix counterparty selector layout

### DIFF
--- a/Price/styles/admin.css
+++ b/Price/styles/admin.css
@@ -228,6 +228,8 @@ label {
 /* Ensure labels in the "Add User" form span the full width */
 .add-user-form label {
     width: 100%;
+    display: flex;
+    align-items: center;
 }
 
 input[type="text"], input[type="password"], input[type="number"], select {
@@ -303,8 +305,9 @@ a:hover {
 
 /* Stretch fields in the "Add User" form */
 .add-user-form select {
-    width: 100%;
+    width: auto;
     box-sizing: border-box;
+    flex: 1;
 }
 
 /* Select2 container should also stretch across the available width */


### PR DESCRIPTION
## Summary
- center label contents horizontally in the "Add User" form
- keep the counterparty selector on the same line as its label

## Testing
- `scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_688d382ae9d0832084b1892da1e218fe