### PR TITLE
Fix path for user data

### DIFF
--- a/Price/function.php
+++ b/Price/function.php
@@ -1,7 +1,8 @@
 <?php
 // Загрузка пользователей из JSON-файла
 function loadUsers(): array {
-    $jsonData = @file_get_contents('casa/xNtxj6hsL2.json');
+    $file = __DIR__ . '/casa/xNtxj6hsL2.json';
+    $jsonData = @file_get_contents($file);
     if ($jsonData === false) {
         return []; // если файла нет или ошибка чтения
     }
@@ -11,5 +12,6 @@ function loadUsers(): array {
 
 // Сохранение массива пользователей в JSON-файл
 function saveUsers(array $users): void {
-    file_put_contents('casa/xNtxj6hsL2.json', json_encode($users, JSON_PRETTY_PRINT));
+    $file = __DIR__ . '/casa/xNtxj6hsL2.json';
+    file_put_contents($file, json_encode($users, JSON_PRETTY_PRINT));
 }


### PR DESCRIPTION
## Summary
- adjust path to `xNtxj6hsL2.json` in `function.php` so passwords save correctly

## Testing
- `php -l Price/function.php`
- `scripts/test.sh`


------
https://chatgpt.com/codex/tasks/task_e_688d3ccd0b088320b83d7456dae1c2c5