### PR TITLE
Fix PRODUCT_ORDER redeclaration

### DIFF
--- a/Price/scripts/rules-loader.js
+++ b/Price/scripts/rules-loader.js
@@ -2,7 +2,6 @@
  * Load column and row sorting rules from JSON files.
  * @returns {Promise<void>}
  */
-let PRODUCT_ORDER = [];
 
 function loadRules() {
   const rulesFile = window.__rulesFile || 'casa/row_sort_rules.json';


### PR DESCRIPTION
## Summary
- remove duplicate `PRODUCT_ORDER` declaration in rules-loader.js

## Testing
- `scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_688d3ed2892c8320b7d801f6bf728e97