### PR TITLE
Fix duplicated variable declaration

### DIFF
--- a/Price/scripts/rules-loader.js
+++ b/Price/scripts/rules-loader.js
@@ -2,7 +2,8 @@
  * Load column and row sorting rules from JSON files.
  * @returns {Promise<void>}
  */
-let PRODUCT_ORDER = [];
+// PRODUCT_ORDER is declared in table.js
+PRODUCT_ORDER = [];
 
 function loadRules() {
   const rulesFile = window.__rulesFile || 'casa/row_sort_rules.json';


### PR DESCRIPTION
## Summary
- avoid redeclaring PRODUCT_ORDER in rules-loader

## Testing
- `scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_688d3ed2892c8320b7d801f6bf728e97