### PR TITLE
Stretch admin tabs across full width

### DIFF
--- a/Price/styles/admin.css
+++ b/Price/styles/admin.css
@@ -160,18 +160,24 @@ header {
 }
 
 .admin-tabs {
-    text-align: center;
+    display: flex;
+    width: 100%;
     margin-bottom: 20px;
 }
 
 .admin-tab {
-    display: inline-block;
+    flex: 1;
+    text-align: center;
     padding: 8px 16px;
-    margin: 0 5px;
     border: 1px solid #004fed;
     border-radius: 6px;
+    background-color: #f0f0f0;
     text-decoration: none;
     color: #004fed;
+}
+
+.admin-tab + .admin-tab {
+    border-left: none;
 }
 
 .admin-tab.active,


### PR DESCRIPTION
## Summary
- Make admin panel tea-type tabs fill their container with flex layout and even widths
- Add background color and borders so tabs are visually distinct and separated

## Testing
- `php -l Price/admin.php`
- `scripts/test.sh`


------
https://chatgpt.com/codex/tasks/task_e_688e05512bf48320b682e515e89262b7