### PR TITLE
Move display rules heading and add tea type label

### DIFF
--- a/Price/admin.php
+++ b/Price/admin.php
@@ -626,13 +626,14 @@ $username = $_SESSION['user']['login'];
     </p>
 </header>
 <div class="admin-container">
+<h3 class="rules-title">Настройка правил отображения товаров</h3>
 <div class="admin-tabs">
 <?php foreach ($adminTabs as $slug => $title): ?>
     <a href="admin.php?tab=<?= $slug ?>" class="admin-tab<?= $slug === $currentTab ? ' active' : '' ?>"><?= htmlspecialchars($title) ?></a>
 <?php endforeach; ?>
 </div>
+<p class="current-tab-info">Какой тип чая выбран: <?= htmlspecialchars($currentTabName) ?></p>
 <!-- Правила сортировки и столбцов -->
-<h3 class="rules-title">Настройка правил отображения товаров — <?= htmlspecialchars($currentTabName) ?></h3>
 <form method="post" action="admin.php?tab=<?= $currentTab ?>" id="rulesForm">
 <div class="sort-rules">
     <h4>Порядок стран</h4>

--- a/Price/styles/admin.css
+++ b/Price/styles/admin.css
@@ -38,6 +38,11 @@ body::before {
     text-align: center;
 }
 
+/* Center the selected tea type label */
+.admin-container .current-tab-info {
+    text-align: center;
+}
+
 /* Header bar for admin page */
 header {
     position: fixed;


### PR DESCRIPTION
## Summary
- Show display rules heading above tea type tabs.
- Add a label displaying the selected tea type beneath the tabs and center it in CSS.

## Testing
- `php -l Price/admin.php`
- `scripts/test.sh`


------
https://chatgpt.com/codex/tasks/task_e_688e1243cd948320a916f197bec9777a