### PR TITLE
style: expand admin column rows

### DIFF
--- a/Price/admin.php
+++ b/Price/admin.php
@@ -625,7 +625,7 @@ $username = $_SESSION['user']['login'];
                         <option value="<?= htmlspecialchars($opt['id']) ?>" <?= $opt['id'] === $col['id'] ? 'selected' : '' ?>><?= htmlspecialchars($opt['title']) ?></option>
                     <?php endforeach; ?>
                 </select>
-                <input type="text" name="col_title[]" value="<?= htmlspecialchars($col['title']) ?>" class="ms-form-control" style="width:150px;" />
+                <input type="text" name="col_title[]" value="<?= htmlspecialchars($col['title']) ?>" class="ms-form-control" />
                 <input type="hidden" name="col_class[]" value="<?= htmlspecialchars($col['class'] ?? '') ?>">
                 <input type="hidden" name="col_enabled[]" class="col-enabled" value="<?= $col['enabled'] ? '1' : '0' ?>">
                 <button type="button" class="toggle-column btn-msk<?= $col['enabled'] ? ' active' : '' ?>">
@@ -924,7 +924,7 @@ function createColumnRow(id, title, cls, enabled) {
         if (key === id) opt.attr('selected', 'selected');
         select.append(opt);
     });
-    var titleInput = $('<input type="text" name="col_title[]" class="ms-form-control" style="width:150px;">').val(title || '');
+    var titleInput = $('<input type="text" name="col_title[]" class="ms-form-control">').val(title || '');
     var classInput = $('<input type="hidden" name="col_class[]">').val(cls || '');
     var enabledInput = $('<input type="hidden" name="col_enabled[]" class="col-enabled">').val(enabled ? '1' : '0');
     var toggleBtn = $('<button type="button" class="toggle-column btn-msk"></button>').text(enabled ? 'Выключить' : 'Включить');

--- a/Price/styles/admin.css
+++ b/Price/styles/admin.css
@@ -106,6 +106,28 @@ header {
     margin-bottom: 5px;
 }
 
+/* Stretch column configuration rows across full width */
+.column-row {
+    display: flex;
+    align-items: center;
+    width: 100%;
+}
+
+.column-row .column-select,
+.column-row .ms-form-control {
+    flex: 1;
+    margin-right: 10px;
+}
+
+.column-row .toggle-column {
+    margin-left: auto;
+    background-color: rgba(255, 255, 255, 0.8);
+}
+
+.column-row .toggle-column:hover {
+    background-color: rgba(255, 255, 255, 0.9);
+}
+
 .column-row.disabled {
     opacity: 0.5;
 }
@@ -268,7 +290,8 @@ h2, h3 {
 form {
     margin: 1em 0;
     padding: 1em;
-    display: inline-block;
+    display: block;
+    width: 100%;
 }
 
 .header-form {


### PR DESCRIPTION
## Summary
- Let column configuration rows stretch to full width in admin panel
- Match "Disable" button background to tea type selection styling

## Testing
- `php -l Price/admin.php`
- `scripts/test.sh`


------
https://chatgpt.com/codex/tasks/task_e_688e9e1455388320b4e508d21ae157e0