### PR TITLE
Show selected tea type in header

### DIFF
--- a/Price/admin.php
+++ b/Price/admin.php
@@ -574,6 +574,7 @@ $username = $_SESSION['user']['login'];
         </form>
         <button type="button" id="openUsersModal" class="header-btn">Редактировать пользователей</button>
     </div>
+    <h2 class="header-title"><?= htmlspecialchars($currentTabName) ?></h2>
     <p class="user-info">
         Вы вошли как: <strong><?= htmlspecialchars($username) ?></strong>
         <a href="logout.php" class="header-btn logout-link">Выйти</a>
@@ -586,7 +587,7 @@ $username = $_SESSION['user']['login'];
     <a href="admin.php?tab=<?= $slug ?>" class="admin-tab<?= $slug === $currentTab ? ' active' : '' ?>"><?= htmlspecialchars($title) ?></a>
 <?php endforeach; ?>
 </div>
-<p class="current-tab-info">Какой тип чая выбран: <?= htmlspecialchars($currentTabName) ?></p>
+
 <!-- Правила сортировки и столбцов -->
 <form method="post" action="admin.php?tab=<?= $currentTab ?>" id="rulesForm">
 <hr>

--- a/Price/styles/admin.css
+++ b/Price/styles/admin.css
@@ -38,11 +38,6 @@ body::before {
     text-align: center;
 }
 
-/* Center the selected tea type label */
-.admin-container .current-tab-info {
-    text-align: center;
-}
-
 /* Header bar for admin page */
 header {
     position: fixed;
@@ -57,9 +52,15 @@ header {
     box-sizing: border-box;
     border: 1px solid rgba(255,255,255,0.3);
     z-index: 1000;
-    display: flex;
-    justify-content: space-between;
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
     align-items: center;
+}
+
+/* Centered title in header */
+.header-title {
+    margin: 0;
+    text-align: center;
 }
 
 /* Container for buttons on the left side of the header */
@@ -269,6 +270,7 @@ header {
 }
 header .user-info {
     margin: 0;
+    justify-self: end;
 }
 
 .product-row {


### PR DESCRIPTION
## Summary
- replace tab info paragraph with a centered header title showing the selected tea type
- switch admin header layout to grid and style centered title

## Testing
- `php -l Price/admin.php`
- `scripts/test.sh`


------
https://chatgpt.com/codex/tasks/task_e_688f556eb4208320a8163621469a8883