### PR TITLE
feat: move edit users button to header left

### DIFF
--- a/Price/admin.php
+++ b/Price/admin.php
@@ -569,10 +569,10 @@ $username = $_SESSION['user']['login'];
 <body class="ms-login-field">
 <header>
     <div class="header-left">
+        <button type="button" id="openUsersModal" class="header-btn">Редактировать пользователей</button>
         <form method="post" action="admin.php?tab=<?= $currentTab ?>" class="header-form">
             <button type="submit" name="loadMs" class="header-btn">Получить данные из Моего Склада</button>
         </form>
-        <button type="button" id="openUsersModal" class="header-btn">Редактировать пользователей</button>
     </div>
     <h2 class="header-title"><?= htmlspecialchars($currentTabName) ?></h2>
     <p class="user-info">

--- a/Price/styles/admin.css
+++ b/Price/styles/admin.css
@@ -187,6 +187,10 @@ header {
     text-decoration: none;
 }
 
+#openUsersModal {
+    white-space: nowrap;
+}
+
 .header-btn:hover {
     background-color: rgba(156, 204, 101);
 }


### PR DESCRIPTION
## Summary
- place "Edit users" button at the start of the admin header
- prevent the edit button label from wrapping

## Testing
- `php -l Price/admin.php`
- `scripts/test.sh`


------
https://chatgpt.com/codex/tasks/task_e_688f581e76f88320a8f5c719e6ffb48c