### PR TITLE
Refactor admin panel layout

### DIFF
--- a/Price/styles/admin.css
+++ b/Price/styles/admin.css
@@ -33,11 +33,8 @@ body::before {
     width: fit-content;
     box-sizing: border-box;
     border: 1px solid rgba(255,255,255,0.3);
-}
-
-/* Заголовок блока правил внутри контейнера */
-.admin-container .rules-title {
-    text-align: center;
+    display: flex;
+    flex-direction: column;
 }
 
 /* Шапка страницы */
@@ -102,38 +99,15 @@ header .user-info {
 }
 
 /* Блок сортировки и таблица колонок */
-.sort-rules {
-    margin: 20px 0;
-}
 
-.column-title {
-    text-align: center;
-}
-
-#columnFields {
-    width: 100%;
-}
-
-.country-row,
-.type-row,
-.product-row {
-    margin-bottom: 5px;
-}
 
 /* Таблица настроек колонок */
 .column-table {
-    width: 100%;
     border-collapse: collapse;
 }
 
 .column-table td {
     border: none;
-    padding: 4px 10px 4px 0;
-}
-
-.column-row .column-select,
-.column-row .ms-form-control {
-    width: 100%;
 }
 
 .column-row .toggle-column {
@@ -153,18 +127,8 @@ header .user-info {
 }
 
 /* Строка продукта в таблице */
-.product-row {
-    display: flex;
-    align-items: center;
-}
-
 .product-row .drag-handle {
     cursor: grab;
-    margin-right: 8px;
-}
-
-.product-row .product-name {
-    flex-grow: 1;
 }
 
 /* Настройки Select2 */
@@ -174,9 +138,6 @@ header .user-info {
 }
 
 .select2-container .select2-selection--single .select2-selection__rendered {
-    display: block;
-    padding-left: 8px;
-    padding-right: 20px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -184,7 +145,6 @@ header .user-info {
 
 /* Кнопки */
 .btn-msk {
-    padding: 10px 25px;
     text-decoration: none;
     border: 2px solid #2855af;
     border-radius: 8px;
@@ -201,12 +161,10 @@ header .user-info {
 }
 
 .header-btn {
-    display: inline-block;
     background-color: rgba(156, 204, 101);
     color: #fff;
     border: none;
     cursor: pointer;
-    padding: 10px;
     border-radius: 5px;
     transition: background-color 0.3s ease;
     text-decoration: none;
@@ -233,16 +191,8 @@ header .user-info {
 }
 
 /* Вкладки в админке */
-.admin-tabs {
-    display: flex;
-    width: 100%;
-    margin-bottom: 20px;
-}
 
 .admin-tab {
-    flex: 1;
-    text-align: center;
-    padding: 8px 16px;
     border: 1px solid rgba(128, 128, 128, 0.5);
     box-shadow: 0 0 4px rgba(128, 128, 128, 0.5);
     background-color: rgba(255, 255, 255, 0.8);
@@ -300,53 +250,12 @@ h2, h3 {
     color: #2c3e50;
 }
 
-form {
-    margin: 1em 0;
-    padding: 1em;
-    display: block;
-    width: 100%;
-}
-
-.header-form {
-    margin: 0;
-    padding: 0;
-}
-
-label {
-    display: block;
-    margin: 0.5em 0;
-}
-
-.add-user-form label {
-    width: 100%;
-    display: flex;
-    align-items: center;
-}
-
-.add-user-form label.centered-label {
-    justify-content: center;
-}
-
-input[type="text"], input[type="password"], input[type="number"], select {
-    padding: 5px;
-    margin-left: 10px;
-}
-
-button {
-    padding: 5px 10px;
-    margin-top: 5px;
-}
-
 table {
     border-collapse: collapse;
-    margin: 1em 0;
-    width: 100%;
 }
 
 table th, table td {
     border: 1px solid #ccc;
-    padding: 8px;
-    text-align: left;
 }
 
 table th {


### PR DESCRIPTION
## Summary
- make `.admin-container` a vertical flex container
- strip positioning rules from admin panel child elements, retaining only visual styles

## Testing
- `./scripts/install.sh`
- `./scripts/test.sh`


------
https://chatgpt.com/codex/tasks/task_e_688f867e4ab48320937fac9e5069d311