### PR TITLE
style: expand admin column table and align control heights

### DIFF
--- a/Price/styles/admin.css
+++ b/Price/styles/admin.css
@@ -115,10 +115,24 @@ header .user-info {
 /* Таблица настроек колонок */
 .column-table {
     border-collapse: collapse;
+    width: 100%;
 }
 
 .column-table td {
     border: none;
+}
+
+.column-table .column-select,
+.column-table .toggle-column,
+.column-table .ms-form-control {
+    height: 44px;
+    box-sizing: border-box;
+}
+
+.column-table .toggle-column {
+    padding: 0 14px;
+    display: inline-flex;
+    align-items: center;
 }
 
 .column-row .toggle-column {


### PR DESCRIPTION
## Summary
- make column settings table use full width of its container
- match selector and toggle button heights to name input field

## Testing
- `php -l Price/admin.php`
- `scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_688fb467a60c832099716b7810ede910