### PR TITLE
Make sorting blocks occupy full width

### DIFF
--- a/Price/admin.php
+++ b/Price/admin.php
@@ -672,9 +672,9 @@ $username = $_SESSION['user']['login'];
                                         </div>
                                     <?php endforeach; ?>
                                 </div>
-                                <input type="text" class="product-search" placeholder="Введите имя товара" style="width:300px;">
+                                <input type="text" class="product-search" placeholder="Введите имя товара">
                                 <button type="button" class="btnSearchProduct">Найти</button>
-                                <select class="productResults" style="width:300px; display:none;"></select>
+                                <select class="productResults" style="display:none;"></select>
                                 <button type="button" class="addProduct" style="display:none;">Добавить</button>
                             </div>
                         <?php endforeach; ?>
@@ -883,9 +883,9 @@ function createTypeBlock(cIndex, value) {
     }
     var remove = $('<button type="button" class="remove-type btn-msk">Удалить тип</button>');
     var prodCont = $('<div class="product-container"></div>');
-    var search = $('<input type="text" class="product-search" placeholder="Введите имя товара" style="width:300px;">');
+    var search = $('<input type="text" class="product-search" placeholder="Введите имя товара">');
     var btnSearch = $('<button type="button" class="btnSearchProduct">Найти</button>');
-    var results = $('<select class="productResults" style="width:300px; display:none;"></select>');
+    var results = $('<select class="productResults" style="display:none;"></select>');
     var addProd = $('<button type="button" class="addProduct" style="display:none;">Добавить</button>');
     block.append(handle, select, remove, prodCont, search, btnSearch, results, addProd);
     return block;

--- a/Price/styles/admin.css
+++ b/Price/styles/admin.css
@@ -157,6 +157,38 @@ header .user-info {
     cursor: grab;
 }
 
+/* Блоки порядка сортировки товаров */
+.sort-rules #countryContainer,
+.sort-rules .country-block,
+.sort-rules .type-container,
+.sort-rules .type-block,
+.sort-rules .product-container,
+.sort-rules .product-row,
+.sort-rules .country-select,
+.sort-rules .type-select,
+.sort-rules .product-search,
+.sort-rules .productResults {
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.sort-rules .country-block,
+.sort-rules .type-block,
+.sort-rules .product-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 10px;
+}
+
+.sort-rules .country-select,
+.sort-rules .type-select,
+.sort-rules .product-search,
+.sort-rules .productResults,
+.sort-rules .product-name {
+    flex: 1;
+}
+
 /* Настройки Select2 */
 .select2-container--default .select2-selection--single .select2-selection__rendered {
     color: #444;


### PR DESCRIPTION
## Summary
- Ensure product sorting search fields and dropdowns expand to full container width
- Add CSS rules so sorting blocks and controls stretch to available width

## Testing
- `php -l Price/admin.php`
- `scripts/test.sh`


------
https://chatgpt.com/codex/tasks/task_e_688fb9055170832091aedddd4e550904