### PR TITLE
Ensure admin sort inputs span full width

### DIFF
--- a/Price/admin.php
+++ b/Price/admin.php
@@ -672,9 +672,9 @@ $username = $_SESSION['user']['login'];
                                         </div>
                                     <?php endforeach; ?>
                                 </div>
-                                <input type="text" class="product-search" placeholder="Введите имя товара" style="width:300px;">
+                                <input type="text" class="product-search" placeholder="Введите имя товара">
                                 <button type="button" class="btnSearchProduct">Найти</button>
-                                <select class="productResults" style="width:300px; display:none;"></select>
+                                <select class="productResults" style="display:none;"></select>
                                 <button type="button" class="addProduct" style="display:none;">Добавить</button>
                             </div>
                         <?php endforeach; ?>
@@ -883,9 +883,9 @@ function createTypeBlock(cIndex, value) {
     }
     var remove = $('<button type="button" class="remove-type btn-msk">Удалить тип</button>');
     var prodCont = $('<div class="product-container"></div>');
-    var search = $('<input type="text" class="product-search" placeholder="Введите имя товара" style="width:300px;">');
+    var search = $('<input type="text" class="product-search" placeholder="Введите имя товара">');
     var btnSearch = $('<button type="button" class="btnSearchProduct">Найти</button>');
-    var results = $('<select class="productResults" style="width:300px; display:none;"></select>');
+    var results = $('<select class="productResults" style="display:none;"></select>');
     var addProd = $('<button type="button" class="addProduct" style="display:none;">Добавить</button>');
     block.append(handle, select, remove, prodCont, search, btnSearch, results, addProd);
     return block;

--- a/Price/styles/admin.css
+++ b/Price/styles/admin.css
@@ -441,3 +441,14 @@ a:hover {
     overflow: hidden;
 }
 
+/* Sort rules: occupy full width */
+.sort-rules select,
+.sort-rules input,
+.sort-rules button,
+.sort-rules .country-block,
+.sort-rules .type-block,
+.sort-rules .product-row {
+    width: 100%;
+    box-sizing: border-box;
+}
+


### PR DESCRIPTION
## Summary
- Let product sorting inputs, selects and buttons stretch to the full width of their container
- Apply full-width rule to dynamically created sort elements
- Add CSS to ensure all sorting controls occupy available space

## Testing
- `php -l Price/admin.php`
- `scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_688fb9055170832091aedddd4e550904