### PR TITLE
Expand product sort inputs to full width

### DIFF
--- a/Price/admin.php
+++ b/Price/admin.php
@@ -672,9 +672,9 @@ $username = $_SESSION['user']['login'];
                                         </div>
                                     <?php endforeach; ?>
                                 </div>
-                                <input type="text" class="product-search" placeholder="Введите имя товара" style="width:300px;">
+                                <input type="text" class="product-search" placeholder="Введите имя товара">
                                 <button type="button" class="btnSearchProduct">Найти</button>
-                                <select class="productResults" style="width:300px; display:none;"></select>
+                                <select class="productResults" style="display:none;"></select>
                                 <button type="button" class="addProduct" style="display:none;">Добавить</button>
                             </div>
                         <?php endforeach; ?>
@@ -883,9 +883,9 @@ function createTypeBlock(cIndex, value) {
     }
     var remove = $('<button type="button" class="remove-type btn-msk">Удалить тип</button>');
     var prodCont = $('<div class="product-container"></div>');
-    var search = $('<input type="text" class="product-search" placeholder="Введите имя товара" style="width:300px;">');
+    var search = $('<input type="text" class="product-search" placeholder="Введите имя товара">');
     var btnSearch = $('<button type="button" class="btnSearchProduct">Найти</button>');
-    var results = $('<select class="productResults" style="width:300px; display:none;"></select>');
+    var results = $('<select class="productResults" style="display:none;"></select>');
     var addProd = $('<button type="button" class="addProduct" style="display:none;">Добавить</button>');
     block.append(handle, select, remove, prodCont, search, btnSearch, results, addProd);
     return block;

--- a/Price/styles/admin.css
+++ b/Price/styles/admin.css
@@ -110,7 +110,25 @@ header .user-info {
 }
 
 /* Блок сортировки и таблица колонок */
+/* Элементы сортировки товаров занимают всю ширину */
+.country-block,
+.type-block,
+.product-row {
+    width: 100%;
+}
 
+.country-block select,
+.type-block select,
+.product-search,
+.productResults {
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.sort-rules .select2-container {
+    width: 100% !important;
+    box-sizing: border-box;
+}
 
 /* Таблица настроек колонок */
 .column-table {


### PR DESCRIPTION
## Summary
- Remove fixed widths from product search fields and results dropdown
- Add CSS so country/type selectors and product search widgets stretch across their container
- Ensure dynamically created blocks also use full-width layout

## Testing
- `php -l Price/admin.php`
- `scripts/test.sh` *(fails: displays PHPUnit usage information)*

------
https://chatgpt.com/codex/tasks/task_e_688fb9055170832091aedddd4e550904